### PR TITLE
feat: Use Git CLI for cloning repositories by default

### DIFF
--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -11,6 +11,7 @@ use tracing::info;
 
 use crate::config::Config;
 use crate::console::create_spinner;
+use crate::git::CloneRepository;
 use crate::path::Path;
 use crate::root::Root;
 use crate::url::Url;
@@ -41,13 +42,15 @@ impl Cmd {
         });
 
         let url = Url::from_str(&self.repo)?;
-        let path = Path::resolve(&root, &url);
+        let path = PathBuf::from(Path::resolve(&root, &url));
         let profile = config
             .rules
             .resolve(&url)
             .and_then(|r| config.profiles.resolve(&r.profile));
 
-        let repo = Repository::clone(&url.to_string(), PathBuf::from(&path))?;
+        config.git.strategy.clone.clone_repository(url, &path)?;
+
+        let repo = Repository::open(&path)?;
         if let Some((name, p)) = profile {
             p.apply(&mut repo.config()?)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,12 +3,15 @@ use std::fs::read_to_string;
 use anyhow::Result;
 use serde::Deserialize;
 
+use crate::git::Config as GitConfig;
 use crate::profile::Profiles;
 use crate::root::Root;
 use crate::rule::Rules;
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Config {
+    #[serde(default)]
+    pub git: GitConfig,
     #[serde(default)]
     pub profiles: Profiles,
     #[serde(default)]

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -1,0 +1,15 @@
+use serde::Deserialize;
+
+use crate::git::strategy::Strategy;
+
+#[derive(Debug, Default, Deserialize)]
+pub struct StrategyConfig {
+    #[serde(default)]
+    pub clone: Strategy,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub strategy: StrategyConfig,
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,0 +1,15 @@
+mod config;
+mod strategy;
+
+pub use config::Config;
+
+use std::path::Path;
+
+use anyhow::Result;
+
+pub trait CloneRepository {
+    fn clone_repository<U, P>(&self, url: U, path: P) -> Result<()>
+    where
+        U: ToString,
+        P: AsRef<Path>;
+}

--- a/src/git/strategy/cli.rs
+++ b/src/git/strategy/cli.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+use std::process::Command;
+
+use tracing::debug;
+
+use crate::git::CloneRepository;
+
+pub struct Cli;
+
+impl CloneRepository for Cli {
+    fn clone_repository<U, P>(&self, url: U, path: P) -> anyhow::Result<()>
+    where
+        U: ToString,
+        P: AsRef<Path>,
+    {
+        debug!("Cloning the repository using CLI strategy");
+
+        let _ = Command::new("git")
+            .args(["clone", &url.to_string(), path.as_ref().to_str().unwrap()])
+            .output()?;
+
+        Ok(())
+    }
+}

--- a/src/git/strategy/git2.rs
+++ b/src/git/strategy/git2.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+
+use git2::Repository;
+use tracing::debug;
+
+use crate::git::CloneRepository;
+
+pub struct Git2;
+
+impl CloneRepository for Git2 {
+    fn clone_repository<U, P>(&self, url: U, path: P) -> anyhow::Result<()>
+    where
+        U: ToString,
+        P: AsRef<Path>,
+    {
+        debug!("Cloning the repository using Git2 strategy");
+
+        let _ = Repository::clone(&url.to_string(), path)?;
+
+        Ok(())
+    }
+}

--- a/src/git/strategy/mod.rs
+++ b/src/git/strategy/mod.rs
@@ -1,0 +1,30 @@
+mod cli;
+mod git2;
+
+pub use {self::git2::Git2, cli::Cli};
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::git::CloneRepository;
+
+#[derive(Debug, Default, Deserialize)]
+pub enum Strategy {
+    #[default]
+    Cli,
+    Git2,
+}
+
+impl CloneRepository for Strategy {
+    fn clone_repository<U, P>(&self, url: U, path: P) -> anyhow::Result<()>
+    where
+        U: ToString,
+        P: AsRef<Path>,
+    {
+        match self {
+            Self::Cli => Cli.clone_repository(url, path),
+            Self::Git2 => Git2.clone_repository(url, path),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cmd;
 mod config;
 mod console;
+mod git;
 mod path;
 mod profile;
 mod root;


### PR DESCRIPTION
The Git backend ghr uses was libgit2 in v0.1 releases.
However, in this strategy, we could not clone repository in an authenticated context (e.g. cloning your private repo, or your organisation's repo).

Now ghr uses Git CLI (`git` command simply) by default.
You can also change this behaviour by modifying `config.toml` file as follows:

```toml
[git]
stategy.clone = "git2"  # `cli` or `git2`
```

Have fun!