### PR TITLE
feat: Open application in a repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Commands:
   clone    Clones a Git repository to local
   delete   Deletes a repository from local
   init     Initialises a Git repository in local
+  open     Opens a repository in an application
   path     Prints the path to root, owner, or a repository
   profile  Manages profiles to use in repositories
   shell    Writes a shell script to extend ghr features

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{anyhow, Result};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Application {
+    cmd: String,
+    args: Vec<String>,
+}
+
+impl Application {
+    pub fn open<P>(&self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let _ = Command::new(&self.cmd)
+            .args(
+                self.args
+                    .iter()
+                    .map(|arg| match arg.as_str() {
+                        "%p" => path.as_ref().to_string_lossy().to_string(),
+                        _ => arg.to_string(),
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .spawn()?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct Applications {
+    #[serde(flatten)]
+    map: HashMap<String, Application>,
+}
+
+impl Applications {
+    pub fn open<P>(&self, name: &str, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        self.get(name)
+            .ok_or_else(|| anyhow!("Application entry does not exists."))?
+            .open(path)
+    }
+}
+
+impl Deref for Applications {
+    type Target = HashMap<String, Application>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -16,7 +16,7 @@ use crate::url::Url;
 
 #[derive(Debug, Parser)]
 pub struct Cmd {
-    /// URL or pattern of the repository to clone.
+    /// URL or pattern of the repository to delete.
     repo: String,
 }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,6 +2,7 @@ mod cd;
 mod clone;
 mod delete;
 mod init;
+mod open;
 mod path;
 mod profile;
 mod shell;
@@ -19,6 +20,8 @@ pub enum Action {
     Delete(delete::Cmd),
     /// Initialises a Git repository in local.
     Init(init::Cmd),
+    /// Opens a repository in an application.
+    Open(open::Cmd),
     /// Prints the path to root, owner, or a repository.
     Path(path::Cmd),
     /// Manages profiles to use in repositories.
@@ -41,6 +44,7 @@ impl Cli {
             Clone(cmd) => cmd.run().await,
             Delete(cmd) => cmd.run().await,
             Init(cmd) => cmd.run(),
+            Open(cmd) => cmd.run(),
             Path(cmd) => cmd.run(),
             Profile(cmd) => cmd.run(),
             Shell(cmd) => cmd.run(),

--- a/src/cmd/open.rs
+++ b/src/cmd/open.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use anyhow::Result;
+use clap::Parser;
+
+use crate::config::Config;
+use crate::path::Path;
+use crate::root::Root;
+use crate::url::Url;
+
+#[derive(Debug, Parser)]
+pub struct Cmd {
+    /// URL or pattern of the repository to open application in.
+    repo: String,
+
+    /// Name of the application entry.
+    application: String,
+}
+
+impl Cmd {
+    pub fn run(self) -> Result<()> {
+        let root = Root::find()?;
+        let config = Config::load_from(&root)?;
+
+        let url = Url::from_str(&self.repo)?;
+        let path = PathBuf::from(Path::resolve(&root, &url));
+
+        config.applications.open(&self.application, path)?;
+
+        Ok(())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::fs::read_to_string;
 use anyhow::Result;
 use serde::Deserialize;
 
+use crate::application::Applications;
 use crate::profile::Profiles;
 use crate::root::Root;
 use crate::rule::Rules;
@@ -11,6 +12,8 @@ use crate::rule::Rules;
 pub struct Config {
     #[serde(default)]
     pub profiles: Profiles,
+    #[serde(default)]
+    pub applications: Applications,
     #[serde(default)]
     pub rules: Rules,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod application;
 mod cmd;
 mod config;
 mod console;


### PR DESCRIPTION
Closes #2 

After cloned a repository, we often want to open some application such as IDE or editor in the cloned repository directory.
We utilised that in a simple way.

To use this feature, you need to configure applications you want to open first.
The following example shows an application entry opening Visual Studio Code.

```toml
[applications.vscode]
cmd = "code"
args = ["%p"]
```

Note that an argument `%p` is replaced by the actual repository path.

Now you can use `ghr clone --open` or `ghr open`:
```sh
ghr clone siketyan/ghr --open vscode
ghr open siketyan/ghr vscode
```