### PR TITLE
feat: Open in intermediate application

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::process::Command;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -13,6 +13,13 @@ pub struct Application {
 }
 
 impl Application {
+    pub fn intermediate(cmd: &str) -> Self {
+        Self {
+            cmd: cmd.to_string(),
+            args: vec![],
+        }
+    }
+
     pub fn open<P>(&self, path: P) -> Result<()>
     where
         P: AsRef<Path>,
@@ -40,13 +47,19 @@ pub struct Applications {
 }
 
 impl Applications {
-    pub fn open<P>(&self, name: &str, path: P) -> Result<()>
+    pub fn open<P>(&self, name: &str, path: P) -> Option<Result<()>>
     where
         P: AsRef<Path>,
     {
-        self.get(name)
-            .ok_or_else(|| anyhow!("Application entry does not exists."))?
-            .open(path)
+        self.get(name).map(|a| a.open(path))
+    }
+
+    pub fn open_or_intermediate<P>(&self, name: &str, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        self.open(name, &path)
+            .unwrap_or_else(|| Application::intermediate(name).open(&path))
     }
 }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -16,7 +16,7 @@ impl Application {
     pub fn intermediate(cmd: &str) -> Self {
         Self {
             cmd: cmd.to_string(),
-            args: vec![],
+            args: vec!["%p".to_string()],
         }
     }
 

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -71,7 +71,7 @@ impl Cmd {
         }
 
         if let Some(app) = self.open {
-            config.applications.open(&app, &path)?;
+            config.applications.open_or_intermediate(&app, &path)?;
 
             info!(
                 "Opened the repository in [{}] successfully.",

--- a/src/cmd/open.rs
+++ b/src/cmd/open.rs
@@ -26,7 +26,9 @@ impl Cmd {
         let url = Url::from_str(&self.repo)?;
         let path = PathBuf::from(Path::resolve(&root, &url));
 
-        config.applications.open(&self.application, path)?;
+        config
+            .applications
+            .open_or_intermediate(&self.application, path)?;
 
         Ok(())
     }


### PR DESCRIPTION
Closes #14 

Now you can open in some of application such as `code`, `phpstorm`, `clion` and more without any configuration, if the app supports opening by invoking in `[cmd] [path]` format.