### PR TITLE
fix: Resolve fish extension does not execute anything with clone and without --cd

### DIFF
--- a/resources/shell/ghr.fish
+++ b/resources/shell/ghr.fish
@@ -17,11 +17,15 @@ end
 function ghr
     if test "$argv[1]" = "cd"
         __ghr_cd $argv[2..]
-    else if test "$argv[1]" = "clone" || test "$argv[1]" = "init"
+        return 0
+    end
+
+    if test "$argv[1]" = "clone" || test "$argv[1]" = "init"
         if contains -- "--cd" $argv[2..]
             command ghr "$argv[1]" $argv[2..] && __ghr_cd (__ghr_remove "--cd" $argv[2..])
+            return 0
         end
-    else
-        command ghr $argv[1..]
     end
+
+    command ghr $argv[1..]
 end


### PR DESCRIPTION
Closes #23 
