### PR TITLE
fix: Resolve bash extension causes shell to exit

### DIFF
--- a/resources/shell/ghr.bash
+++ b/resources/shell/ghr.bash
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -eu
-
 __GHR=$(which ghr | head -n 1)
 
 __ghr_cd() {


### PR DESCRIPTION
Hi, @siketyan.
I have been using your ghr.
Source code management has become very comfortable. Thank you very much!!!

This PR fixes a small bug that caused the interactive shell to exit when executing commands that fail after installing the [bash extension](https://github.com/siketyan/ghr#bash).

```bash
$ echo 'eval "$(ghr shell bash)"' >> .bashrc # or other shell config file

$ exec $SHELL -l

$ false # interactive shell exit here
```

This problem was caused by `set -e` in [resources/shell/ghr.bash](https://github.com/siketyan/ghr/compare/main...ryuma017:ghr:fix/bash-extension-bug#diff-73ca25104e6db5b2abbb61a14cf2ae457c6de08900142bb0bf5ffad0a948132c), so this line has been removed.
Similarly, `set -u` has been removed because it may cause problems for some users (as it did for me).

Thank you!