### PR TITLE
feat: Use ghr.toml instead config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ ghr cd <url_or_pattern>
 ```
 
 ### Attaching profiles
-Create `~/.ghr/config.toml` and edit as you like:
+Create `~/.ghr/ghr.toml` and edit as you like:
 
 ```toml
 [profiles.default]
@@ -116,7 +116,7 @@ profile.name = "default"
 ```
 
 ### Configuring applications to open repos in
-Edit `~/.ghr/config.toml` and add entries as you like:
+Edit `~/.ghr/ghr.toml` and add entries as you like:
 
 ```toml
 [applications.vscode]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,9 @@
 use std::fs::read_to_string;
+use std::path::Path;
 
 use anyhow::Result;
 use serde::Deserialize;
+use tracing::warn;
 
 use crate::application::Applications;
 use crate::git::Config as GitConfig;
@@ -23,15 +25,30 @@ pub struct Config {
 
 impl Config {
     pub fn load_from(root: &Root) -> Result<Self> {
-        let path = root.path().join("config.toml");
+        Ok(match Self::load_from_path(root.path().join("ghr.toml"))? {
+            Some(c) => c,
+            None => {
+                warn!(
+                    "Using `config.toml` is deprecated since ghr v0.2.3 and \
+                    it won't be supported from v0.3. Move them to `ghr.toml` to migrate.",
+                );
 
-        Ok(match path.exists() {
-            true => toml::from_str(read_to_string(path)?.as_str())?,
-            _ => Self::default(),
+                Self::load_from_path(root.path().join("config.toml"))?.unwrap_or_default()
+            }
         })
     }
 
     pub fn load() -> Result<Self> {
         Self::load_from(&Root::find()?)
+    }
+
+    fn load_from_path<P>(path: P) -> Result<Option<Self>>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(match path.as_ref().exists() {
+            true => Some(toml::from_str(read_to_string(path)?.as_str())?),
+            _ => None,
+        })
     }
 }


### PR DESCRIPTION
Migration Guide: simply move your config.toml to ghr.toml in the same directory. No contents modification required.