### PR TITLE
feat: Resolve <repo> pattern using default owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ If you have installed the shell extension, you can change directory into the clo
 ghr clone <url_or_pattern> --cd
 ```
 
+If you often use repositories of a specific owner, you can set the default owner to be resolved.
+
+```toml
+[defaults]
+owner = "siketyan"
+```
+
+```shell
+ghr clone <repo>
+```
+
 ### Changing directory
 You can change directory into a repository on the shell.
 It requires installing the shell extension.

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::mpsc::channel;
 use std::time::Duration;
 
@@ -45,7 +44,7 @@ impl Cmd {
             p.finish_and_clear();
         });
 
-        let url = Url::from_str(&self.repo)?;
+        let url = Url::from_str(&self.repo, config.defaults.owner.as_deref())?;
         let path = PathBuf::from(Path::resolve(&root, &url));
         let profile = config
             .rules

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::mpsc::channel;
 use std::time::Duration;
 
+use crate::config::Config;
 use anyhow::Result;
 use clap::Parser;
 use console::style;
@@ -23,6 +23,7 @@ pub struct Cmd {
 impl Cmd {
     pub async fn run(self) -> Result<()> {
         let root = Root::find()?;
+        let config = Config::load_from(&root)?;
 
         if !Confirm::new()
             .with_prompt(format!(
@@ -34,7 +35,7 @@ impl Cmd {
             return Ok(());
         }
 
-        let url = Url::from_str(&self.repo)?;
+        let url = Url::from_str(&self.repo, config.defaults.owner.as_deref())?;
         let path = PathBuf::from(Path::resolve(&root, &url));
 
         let (tx, rx) = channel();

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use anyhow::Result;
 use clap::Parser;
@@ -32,7 +31,7 @@ impl Cmd {
         let root = Root::find()?;
         let config = Config::load_from(&root)?;
 
-        let url = Url::from_str(&self.repo)?;
+        let url = Url::from_str(&self.repo, config.defaults.owner.as_deref())?;
         let path = Path::resolve(&root, &url);
         let profile = config
             .rules

--- a/src/cmd/open.rs
+++ b/src/cmd/open.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use anyhow::Result;
 use clap::Parser;
@@ -23,7 +22,7 @@ impl Cmd {
         let root = Root::find()?;
         let config = Config::load_from(&root)?;
 
-        let url = Url::from_str(&self.repo)?;
+        let url = Url::from_str(&self.repo, config.defaults.owner.as_deref())?;
         let path = PathBuf::from(Path::resolve(&root, &url));
 
         config

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,14 @@ use crate::root::Root;
 use crate::rule::Rules;
 
 #[derive(Debug, Default, Deserialize)]
+pub struct Defaults {
+    pub owner: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
 pub struct Config {
+    #[serde(default)]
+    pub defaults: Defaults,
     #[serde(default)]
     pub git: GitConfig,
     #[serde(default)]

--- a/src/url.rs
+++ b/src/url.rs
@@ -286,6 +286,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_from_pattern_repo() {
+        assert_eq!(
+            Url {
+                vcs: Vcs::Git,
+                scheme: Scheme::Https,
+                user: None,
+                host: Host::GitHub,
+                owner: "siketyan".to_string(),
+                repo: "siketyan.github.io".to_string()
+            },
+            Url::from_pattern("siketyan.github.io", Some("siketyan")).unwrap(),
+        )
+    }
+
+    #[test]
     fn parse_from_pattern_org_repo() {
         assert_eq!(
             Url {
@@ -296,7 +311,7 @@ mod tests {
                 owner: "siketyan".to_string(),
                 repo: "siketyan.github.io".to_string()
             },
-            Url::from_pattern("siketyan/siketyan.github.io").unwrap(),
+            Url::from_pattern("siketyan/siketyan.github.io", None).unwrap(),
         )
     }
 
@@ -311,7 +326,7 @@ mod tests {
                 owner: "siketyan".to_string(),
                 repo: "siketyan.github.io".to_string()
             },
-            Url::from_pattern("gitlab.com:siketyan/siketyan.github.io").unwrap(),
+            Url::from_pattern("gitlab.com:siketyan/siketyan.github.io", None).unwrap(),
         )
     }
 
@@ -326,7 +341,7 @@ mod tests {
                 owner: "siketyan".to_string(),
                 repo: "siketyan.github.io".to_string()
             },
-            Url::from_pattern("git@github.com:siketyan/siketyan.github.io.git").unwrap(),
+            Url::from_pattern("git@github.com:siketyan/siketyan.github.io.git", None).unwrap(),
         )
     }
 


### PR DESCRIPTION
ghr now supports resolving <repo> only pattern if you have setup the default owner.
Setting the default is so easy:

```toml
[defaults]
owner = "siketyan"
```

Add this to your `ghr.toml` and done!

Now you can init/clone/open/delete repos without specifying the owner.

```shell
ghr clone <repo>
```