### PR TITLE
feat: Support cloning submodules recursively

### DIFF
--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -11,7 +11,7 @@ use tracing::info;
 
 use crate::config::Config;
 use crate::console::create_spinner;
-use crate::git::CloneRepository;
+use crate::git::{CloneOptions, CloneRepository};
 use crate::path::Path;
 use crate::root::Root;
 use crate::url::Url;
@@ -20,6 +20,10 @@ use crate::url::Url;
 pub struct Cmd {
     /// URL or pattern of the repository to clone.
     repo: String,
+
+    /// Clones their submodules recursively.
+    #[clap(short, long)]
+    recursive: bool,
 
     /// Change directory after cloned a repository (Shell extension required).
     #[clap(long)]
@@ -52,7 +56,13 @@ impl Cmd {
             .resolve(&url)
             .and_then(|r| config.profiles.resolve(&r.profile));
 
-        config.git.strategy.clone.clone_repository(url, &path)?;
+        config.git.strategy.clone.clone_repository(
+            url,
+            &path,
+            &CloneOptions {
+                recursive: self.recursive,
+            },
+        )?;
 
         let repo = Repository::open(&path)?;
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -7,8 +7,13 @@ use std::path::Path;
 
 use anyhow::Result;
 
+#[derive(Debug, Default)]
+pub struct CloneOptions {
+    pub recursive: bool,
+}
+
 pub trait CloneRepository {
-    fn clone_repository<U, P>(&self, url: U, path: P) -> Result<()>
+    fn clone_repository<U, P>(&self, url: U, path: P, options: &CloneOptions) -> Result<()>
     where
         U: ToString,
         P: AsRef<Path>;

--- a/src/git/strategy/cli.rs
+++ b/src/git/strategy/cli.rs
@@ -3,21 +3,25 @@ use std::process::Command;
 
 use tracing::debug;
 
-use crate::git::CloneRepository;
+use crate::git::{CloneOptions, CloneRepository};
 
 pub struct Cli;
 
 impl CloneRepository for Cli {
-    fn clone_repository<U, P>(&self, url: U, path: P) -> anyhow::Result<()>
+    fn clone_repository<U, P>(&self, url: U, path: P, options: &CloneOptions) -> anyhow::Result<()>
     where
         U: ToString,
         P: AsRef<Path>,
     {
         debug!("Cloning the repository using CLI strategy");
 
-        let _ = Command::new("git")
-            .args(["clone", &url.to_string(), path.as_ref().to_str().unwrap()])
-            .output()?;
+        let url = url.to_string();
+        let mut args = vec!["clone", &url, path.as_ref().to_str().unwrap()];
+        if options.recursive {
+            args.push("--recursive");
+        }
+
+        let _ = Command::new("git").args(args).output()?;
 
         Ok(())
     }

--- a/src/git/strategy/git2.rs
+++ b/src/git/strategy/git2.rs
@@ -3,19 +3,22 @@ use std::path::Path;
 use git2::Repository;
 use tracing::debug;
 
-use crate::git::CloneRepository;
+use crate::git::{CloneOptions, CloneRepository};
 
 pub struct Git2;
 
 impl CloneRepository for Git2 {
-    fn clone_repository<U, P>(&self, url: U, path: P) -> anyhow::Result<()>
+    fn clone_repository<U, P>(&self, url: U, path: P, options: &CloneOptions) -> anyhow::Result<()>
     where
         U: ToString,
         P: AsRef<Path>,
     {
         debug!("Cloning the repository using Git2 strategy");
 
-        let _ = Repository::clone(&url.to_string(), path)?;
+        let _ = match options.recursive {
+            true => Repository::clone_recurse(&url.to_string(), path)?,
+            _ => Repository::clone(&url.to_string(), path)?,
+        };
 
         Ok(())
     }

--- a/src/git/strategy/mod.rs
+++ b/src/git/strategy/mod.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::git::CloneRepository;
+use crate::git::{CloneOptions, CloneRepository};
 
 #[derive(Debug, Default, Deserialize)]
 pub enum Strategy {
@@ -17,14 +17,14 @@ pub enum Strategy {
 }
 
 impl CloneRepository for Strategy {
-    fn clone_repository<U, P>(&self, url: U, path: P) -> anyhow::Result<()>
+    fn clone_repository<U, P>(&self, url: U, path: P, options: &CloneOptions) -> anyhow::Result<()>
     where
         U: ToString,
         P: AsRef<Path>,
     {
         match self {
-            Self::Cli => Cli.clone_repository(url, path),
-            Self::Git2 => Git2.clone_repository(url, path),
+            Self::Cli => Cli.clone_repository(url, path, options),
+            Self::Git2 => Git2.clone_repository(url, path, options),
         }
     }
 }


### PR DESCRIPTION
As an initial action of #36, now ghr supports cloning submodules recursively.
