### PR TITLE
docs: change phrasing of `cd` related text

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ghr shell fish --completion | source
 Usage: ghr <COMMAND>
 
 Commands:
-  cd       Changes directory into a repository (Shell extension required)
+  cd       Change directory to one of the managed repositories (Shell extension required)
   clone    Clones a Git repository to local
   delete   Deletes a repository from local
   init     Initialises a Git repository in local
@@ -94,7 +94,7 @@ ghr clone ssh://git@github.com/<owner>/<repo>.git
 ghr clone git@github.com:<owner>/<repo>.git
 ```
 
-If you have installed the shell extension, you can change directory into the cloned repository:
+If you have installed the shell extension, you can change directory to the cloned repository:
 
 ```shell
 ghr clone <url_or_pattern> --cd
@@ -112,7 +112,7 @@ ghr clone <repo>
 ```
 
 ### Changing directory
-You can change directory into a repository on the shell.
+You can change directory to one of the managed repositories on the shell.
 It requires installing the shell extension.
 
 ```shell

--- a/src/cmd/cd.rs
+++ b/src/cmd/cd.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 pub struct Cmd {
-    /// URL or pattern of the repository to change directory into.
+    /// URL or pattern of the repository where to change directory to.
     repo: String,
 }
 

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -29,11 +29,11 @@ pub struct Cmd {
     #[clap(short, long)]
     recursive: bool,
 
-    /// Change directory after cloned a repository (Shell extension required).
+    /// Change directory after cloning the repository (Shell extension required).
     #[clap(long)]
     cd: bool,
 
-    /// Opens the directory after cloned a repository.
+    /// Opens the directory after cloning the repository.
     #[clap(long)]
     open: Option<Option<String>>,
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -14,7 +14,7 @@ use clap::{Parser, Subcommand};
 
 #[derive(Debug, Subcommand)]
 pub enum Action {
-    /// Changes directory into a repository (Shell extension required).
+    /// Change directory to one of the managed repositories (Shell extension required).
     Cd(cd::Cmd),
     /// Clones a Git repository to local.
     Clone(clone::Cmd),


### PR DESCRIPTION
I rephrased some text about `cd` because "change sth into ~" has a different meaning to what the command acutually does