### PR TITLE
fix: Resolve that `--cd` used with `clone` and `init` does not work on bash

### DIFF
--- a/resources/shell/bash/ghr.bash
+++ b/resources/shell/bash/ghr.bash
@@ -35,7 +35,7 @@ ghr() {
 
         if { [ "$1" = "clone" ] || [ "$1" = "init" ]; } && __ghr_contains "--cd" ${@:2}; then
             $__GHR "$1" ${@:2}
-            __ghr_cd ${@:2}
+            __ghr_cd "$(__ghr_remove "--cd" ${@:2})"
             return
         fi
     fi


### PR DESCRIPTION
Hi, @siketyan !

This PR fixes a bug in the bash extension that prevented the `--cd` option used with `clone` and `init` from working properly.

Prior to this correction, the following error occurred:

<img width="913" alt="before" src="https://user-images.githubusercontent.com/83487941/231788961-3a9a7f66-2976-4691-b44e-46f82a43c6bc.png">

This problem occurred because the correct arguments were not given to `__ghr_cd()`.
Therefore, `__ghr_remove()`, which was defined but not used, was utilized to resolve this problem.

And now everything works correctly.

<img width="913" alt="after" src="https://user-images.githubusercontent.com/83487941/231795945-4263b295-85c2-4f75-aad9-6a6cdefa2bcb.png">

Thank you!