### PR TITLE
fix: fix a number of issues in `add` subcommand

### DIFF
--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -1,7 +1,7 @@
-use std::fs::rename;
+use std::fs::{create_dir_all, rename};
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use console::style;
 use dialoguer::Confirm;
@@ -78,6 +78,20 @@ impl Cmd {
                 .interact()?
         {
             return Ok(());
+        }
+
+        let parent_path = path
+            .parent()
+            .ok_or_else(|| {
+                anyhow!(
+                    "Failed to determine parent path for the repository's new location: {}",
+                    path.to_string_lossy()
+                )
+            })?
+            .to_path_buf();
+
+        if !parent_path.as_path().is_dir() {
+            create_dir_all(&parent_path)?
         }
 
         rename(&self.repo, &path)?;

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -100,6 +100,8 @@ impl Cmd {
             path.to_string_lossy(),
         );
 
+        let repo = Repository::open(&path)?;
+
         if let Some((name, p)) = profile {
             p.apply(&mut repo.config()?)?;
 

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -90,9 +90,7 @@ impl Cmd {
             })?
             .to_path_buf();
 
-        if !parent_path.as_path().is_dir() {
-            create_dir_all(&parent_path)?
-        }
+        create_dir_all(&parent_path)?;
 
         rename(&self.repo, &path)?;
         info!(

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -90,7 +90,7 @@ impl Cmd {
             })?
             .to_path_buf();
 
-        create_dir_all(&parent_path)?;
+        create_dir_all(parent_path)?;
 
         rename(&self.repo, &path)?;
         info!(


### PR DESCRIPTION
This PR fixes a number of issues in the `add` subcommand.

The following error occurred when using the `add` subcommand if the `owner` directory did not exist in the ghr path.

```
ERROR No such file or directory (os error 2)
```

This was thought to be caused by `fs::rename()`, so I added a process to create the parent directory before that.

Also, when applying a profile to a config file, the `repo` variable did not point to the destination repository and the following error occurred.

```
ERROR failed to create locked file '{REPOSITORY_PATH_BEFORE_MOVE}/.git/config.lock': No such file or directory; class=Os (2); code=NotFound (-3)
```

So I have fixed this problem.

Thank you in advance!