### PR TITLE
build: Downgrade MSRV to 1.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 homepage = "https://github.com/siketyan/ghr"
 repository = "https://github.com/siketyan/ghr.git"
 readme = "README.md"
-rust-version = "1.75.0"
+rust-version = "1.74.0"
 edition = "2021"
 authors = [
     "Naoki Ikeguchi <me@s6n.jp>",


### PR DESCRIPTION
Latest stable is 1.75 but it is not published to homebrew/homebrew-core tap. In the mean time, we use 1.74 for MSRV.