### PR TITLE
feat: Improve GitHub token handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,9 @@ checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
@@ -350,9 +350,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -1044,11 +1044,11 @@ dependencies = [
 
 [[package]]
 name = "gh-config"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6038ebf9f1bd6e6e935e6d77a5c2daded71668a89b307b7faf8f0257327f851f"
+checksum = "984515bebc643fafe156258b792f30b2a9b17e29d658255e53bbb58700825226"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "dirs",
  "hex",
  "secret-service",
@@ -1056,7 +1056,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "thiserror",
- "windows 0.54.0",
+ "windows",
 ]
 
 [[package]]
@@ -1089,7 +1089,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "walkdir",
- "windows 0.56.0",
+ "windows",
 ]
 
 [[package]]
@@ -1104,7 +1104,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1467,7 +1467,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "libc",
  "redox_syscall",
 ]
@@ -1700,7 +1700,7 @@ checksum = "68a8a3df00728324ad654ecd1ed449a60157c55b7ff8c109af3a35989687c367"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "chrono",
@@ -2117,7 +2117,7 @@ version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.12",
@@ -2232,11 +2232,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2245,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2351,7 +2351,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2569,18 +2569,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2771,7 +2771,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da193277a4e2c33e59e09b5861580c33dd0a637c3883d0fa74ba40c0374af2e"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "bytes",
  "futures-util",
  "http",
@@ -3075,16 +3075,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
@@ -3098,16 +3088,6 @@ name = "windows-core"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
  "windows-result",
  "windows-targets 0.52.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5"
 walkdir = "2.5"
 
-gh-config = { version = "0.3.2", optional = true }
+gh-config = { version = "0.4.0", optional = true }
 octocrab = { version = "0.38.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -165,10 +165,10 @@ impl Cmd {
             let root = Arc::clone(&root);
             let config = Arc::clone(&config);
 
-            spinner = spinner.with_spin_while(
-                format!("Cloning from {}...", url.to_string()),
-                move || async move { this.as_ref().clone(&root, &config, url).await },
-            );
+            spinner = spinner
+                .with_spin_while(format!("Cloning from {}...", &url), move || async move {
+                    this.as_ref().clone(&root, &config, url).await
+                });
         }
 
         Ok(spinner.collect().await?.into_iter().collect())

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use anyhow::{anyhow, Error, Result};
@@ -223,10 +224,10 @@ impl FromStr for Vcs {
     }
 }
 
-impl ToString for Vcs {
-    fn to_string(&self) -> String {
+impl Display for Vcs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Git => "git".to_string(),
+            Self::Git => write!(f, "git"),
         }
     }
 }
@@ -250,13 +251,12 @@ impl FromStr for Scheme {
     }
 }
 
-impl ToString for Scheme {
-    fn to_string(&self) -> String {
+impl Display for Scheme {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Https => "https",
-            Self::Ssh => "ssh",
+            Self::Https => write!(f, "https"),
+            Self::Ssh => write!(f, "ssh"),
         }
-        .to_string()
     }
 }
 
@@ -278,11 +278,11 @@ impl FromStr for Host {
     }
 }
 
-impl ToString for Host {
-    fn to_string(&self) -> String {
+impl Display for Host {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::GitHub => GITHUB_COM.to_string(),
-            Self::Unknown(s) => s.clone(),
+            Self::GitHub => write!(f, "{}", GITHUB_COM),
+            Self::Unknown(s) => write!(f, "{}", s),
         }
     }
 }
@@ -374,20 +374,21 @@ impl Url {
     }
 }
 
-impl ToString for Url {
-    fn to_string(&self) -> String {
+impl Display for Url {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(r) = &self.raw {
-            return r.to_string();
+            return write!(f, "{}", r);
         }
 
         let authority = match &self.user {
-            Some(u) => format!("{}@{}", u, self.host.to_string()),
+            Some(u) => format!("{}@{}", u, &self.host),
             _ => self.host.to_string(),
         };
 
         match self.scheme {
             Scheme::Https => {
-                format!(
+                write!(
+                    f,
                     "https://{}/{}/{}{}",
                     authority,
                     self.owner,
@@ -396,7 +397,8 @@ impl ToString for Url {
                 )
             }
             Scheme::Ssh => {
-                format!(
+                write!(
+                    f,
                     "{}:{}/{}{}",
                     authority,
                     self.owner,


### PR DESCRIPTION
Closes #353 

GitHub integration of ghr is made on top of gh CLI, it is required to login to gh before using any GitHub related functions in ghr. In this pull request, we try to improve the error message on failed to retrieve token (see #371) and support reading token from env even if gh is not installed.