### PR TITLE
fix: Use ghr list when query is empty

### DIFF
--- a/resources/shell/bash/ghr-completion.bash
+++ b/resources/shell/bash/ghr-completion.bash
@@ -13,7 +13,11 @@ __ghr_complete__repos() {
     return
   fi
 
-  ghr search "$1"
+  if [ "$1" = '' ]; then
+    ghr list
+  else
+    ghr search "$1"
+  fi
 }
 
 __ghr_complete__profiles() {

--- a/resources/shell/fish/ghr-completion.fish
+++ b/resources/shell/fish/ghr-completion.fish
@@ -2,6 +2,14 @@ function __fish_is_arg_n --argument-names n
     test $n -eq (count (string match -v -- '-*' (commandline -poc)))
 end
 
+function __ghr_complete_repos
+    if test $query = ''
+        ghr list
+    else
+        ghr search (commandline -ct)
+    end
+end
+
 # Disable the default filename completion
 complete -c ghr -f
 
@@ -25,7 +33,7 @@ complete -c ghr -n "__fish_is_arg_n 1" -a version -d "Prints the version of this
 complete -c ghr -n "__fish_is_arg_n 2; and __fish_seen_subcommand_from add" -f
 
 # Complete the 2nd argument of cd, delete, path, open, and browse commands using the repository list
-complete -c ghr -n "__fish_is_arg_n 2; and __fish_seen_subcommand_from browse cd delete path open" -a "(ghr search (commandline -ct))"
+complete -c ghr -n "__fish_is_arg_n 2; and __fish_seen_subcommand_from browse cd delete path open" -a "(__ghr_complete_repos)"
 
 # Complete the 3rd argument of open command using the known command list
 complete -c ghr -n "__fish_is_arg_n 3; and __fish_seen_subcommand_from open" -a "(complete -C '')"


### PR DESCRIPTION
Follow-up of #388 

While query is empty or not typed yet, the argument passed to `ghr search` will be empty and it causes a validation error. We don't need fuzzy searching in this situation, so let's continue using `ghr list` here.